### PR TITLE
removed static throw_error from header

### DIFF
--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -23,7 +23,7 @@
 /* Error handling varies between POSIX and WinSock. */
 #ifdef _WIN32
     #define MVM_IS_SOCKET_ERROR(x) ((x) == SOCKET_ERROR)
-    static void throw_error(MVMThreadContext *tc, int r, char *operation) {
+    MVM_NO_RETURN static void throw_error(MVMThreadContext *tc, int r, char *operation) MVM_NO_RETURN_GCC {
         int error = WSAGetLastError();
         LPTSTR error_string = NULL;
         if (FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
@@ -35,7 +35,7 @@
     }
 #else
     #define MVM_IS_SOCKET_ERROR(x) ((x) < 0)
-    static void throw_error(MVMThreadContext *tc, int r, char *operation) {
+    MVM_NO_RETURN static void throw_error(MVMThreadContext *tc, int r, char *operation) MVM_NO_RETURN_GCC {
         MVM_exception_throw_adhoc(tc, "Could not %s: %s", operation, strerror(errno));
     }
 #endif

--- a/src/io/syncsocket.c
+++ b/src/io/syncsocket.c
@@ -21,9 +21,10 @@
 #define PACKET_SIZE 65535
 
 /* Error handling varies between POSIX and WinSock. */
+MVM_NO_RETURN static void throw_error(MVMThreadContext *tc, int r, char *operation) MVM_NO_RETURN_GCC;
 #ifdef _WIN32
     #define MVM_IS_SOCKET_ERROR(x) ((x) == SOCKET_ERROR)
-    MVM_NO_RETURN static void throw_error(MVMThreadContext *tc, int r, char *operation) MVM_NO_RETURN_GCC {
+    static void throw_error(MVMThreadContext *tc, int r, char *operation) {
         int error = WSAGetLastError();
         LPTSTR error_string = NULL;
         if (FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
@@ -35,7 +36,7 @@
     }
 #else
     #define MVM_IS_SOCKET_ERROR(x) ((x) < 0)
-    MVM_NO_RETURN static void throw_error(MVMThreadContext *tc, int r, char *operation) MVM_NO_RETURN_GCC {
+    static void throw_error(MVMThreadContext *tc, int r, char *operation) {
         MVM_exception_throw_adhoc(tc, "Could not %s: %s", operation, strerror(errno));
     }
 #endif

--- a/src/io/syncsocket.h
+++ b/src/io/syncsocket.h
@@ -1,4 +1,3 @@
-MVM_NO_RETURN static void throw_error(MVMThreadContext *tc, int r, char *operation) MVM_NO_RETURN_GCC;
 MVMObject * MVM_io_socket_create(MVMThreadContext *tc, MVMint64 listen);
 struct sockaddr * MVM_io_resolve_host_name(MVMThreadContext *tc, MVMString *host, MVMint64 port);
 MVMString * MVM_io_get_hostname(MVMThreadContext *tc);


### PR DESCRIPTION
throw_error will never return: __attribute__((noreturn)) (MVM_NO_RETURN_*), and it's static, so no need to have it in the header (noreturn may not work when applied on a definition).